### PR TITLE
Add verbose errors to parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ name = "gpt-common"
 version = "0.1.0"
 dependencies = [
  "nom",
+ "thiserror",
 ]
 
 [[package]]

--- a/gpt-common/Cargo.toml
+++ b/gpt-common/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 nom = "7"
+thiserror = "1"

--- a/gpt-common/src/lib.rs
+++ b/gpt-common/src/lib.rs
@@ -1,18 +1,26 @@
 use dto::NTuple;
+use nom::error::convert_error;
 use parser::parse_gpt_to_features;
+use prelude::{GPTError, Result};
 use test_case_generator::generate_test_cases_for_multiple_features;
 
 pub mod dto;
 mod interval;
 mod parser;
+pub mod prelude;
 mod test_case_generator;
 pub mod test_value_generator;
 mod util;
 
-pub fn generate_tests_for_gpt_input(input: &str) -> Vec<NTuple> {
-    // TODO: Use thiserror and clean up these unwraps
-    let (_, features) = parse_gpt_to_features(input).unwrap();
-    let test_cases = generate_test_cases_for_multiple_features(&features).unwrap();
+use nom::Err;
 
-    test_cases
+pub fn generate_tests_for_gpt_input(input: &str) -> Result<Vec<NTuple>> {
+    let (_, features) = parse_gpt_to_features(input).map_err(|error| match error {
+        Err::Error(err) | Err::Failure(err) => GPTError::ParseError(convert_error(input, err)),
+        Err::Incomplete(err) => GPTError::UnknownParseError(format!("{:?}", err)),
+    })?;
+    let test_cases = generate_test_cases_for_multiple_features(&features)
+        .map_err(|err| GPTError::IntervalError(format!("{:?}", err)))?;
+
+    Ok(test_cases)
 }

--- a/gpt-common/src/parser.rs
+++ b/gpt-common/src/parser.rs
@@ -580,9 +580,9 @@ mod tests {
         assert_eq!(number("-123.0"), Ok(("", -123.0)));
         assert_eq!(number("123.123"), Ok(("", 123.123)));
         assert_eq!(number("123.123000000"), Ok(("", 123.123)));
-        assert_eq!(number("123."), Ok((".", 123.0)));
         assert_eq!(number("-Inf"), Ok(("", f32::NEG_INFINITY)));
         assert_eq!(number("Inf"), Ok(("", f32::INFINITY)));
+        assert!(number("123.").is_err());
         assert!(number("other").is_err());
     }
 

--- a/gpt-common/src/prelude.rs
+++ b/gpt-common/src/prelude.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GPTError {
+    #[error("Parse error: {0}")]
+    ParseError(String),
+
+    #[error("Unknown Parse error: {0}")]
+    UnknownParseError(String),
+
+    #[error("Interval error in logic: {0}")]
+    IntervalError(String),
+
+    #[error("Unknown error")]
+    Unknown,
+}
+
+pub type Result<T> = std::result::Result<T, GPTError>;

--- a/gpt-frontend/src/components/error_display.rs
+++ b/gpt-frontend/src/components/error_display.rs
@@ -1,0 +1,16 @@
+use yew::prelude::*;
+
+#[derive(PartialEq, Eq, Properties)]
+pub struct Props {
+    pub error_text: String,
+}
+
+#[function_component(ErrorDisplay)]
+pub fn error_display(props: &Props) -> Html {
+    html! {
+        <div>
+            <h2>{ "Error" }</h2>
+            <pre>{ &props.error_text }</pre>
+        </div>
+    }
+}

--- a/gpt-frontend/src/components/manual_tester.rs
+++ b/gpt-frontend/src/components/manual_tester.rs
@@ -39,9 +39,22 @@ pub fn manual_tester() -> Html {
             is_loading.set(true);
             generated_state.set(None);
 
-            let test_cases = generate_tests_for_gpt_input(&input);
+            match generate_tests_for_gpt_input(&input) {
+                Ok(test_cases) => {
+                    generated_state.set(Some(test_cases));
+                }
+                Err(err) => {
+                    web_sys::window()
+                        .unwrap()
+                        .alert_with_message(&format!(
+                            "Press F12 and see the well formatted error in the console (TODO)\n{}",
+                            err
+                        ))
+                        .unwrap();
+                    log::error!("Error: {}", err);
+                }
+            }
 
-            generated_state.set(Some(test_cases));
             is_loading.set(false);
         })
     };

--- a/gpt-frontend/src/components/mod.rs
+++ b/gpt-frontend/src/components/mod.rs
@@ -1,3 +1,4 @@
+mod error_display;
 pub mod manual_tester;
 pub mod test_case_table;
 pub mod usage_guide;


### PR DESCRIPTION
Closes #43
## Parser
- Switched `IResult` error type to `VerboseError`
- Added `context`s to the parser to add context to verbose errors
- Added `cut`s to parser which should fail if they can't parse their whole input. This helps cases, where there is an `alt` which would try the next parser if the previous failed, but indeed that parser should have failed. For example while parsing a float, if I've parsed `12.` there must be a number following that. If the parser fails after the dot, it should fail for real.

## Frontend
- Added error handling
  - When there is an error, instead of the test case table, the error will appear
  - The error gets logged to the console